### PR TITLE
Add Stripe founding pricing and PostHog feature flags

### DIFF
--- a/src/app/_lib/posthog.ts
+++ b/src/app/_lib/posthog.ts
@@ -14,6 +14,14 @@ export type FlagsMatcher = Record<string, undefined | {
 
 export const FeatureFlags = {
     IS_APP_DISABLED: 'is_app_disabled',
+    INVITE_ONLY: 'invite-only',
+    FOUNDING_LANDING: 'founding-landing',
+    EMAIL_SEQUENCES: 'email-sequences',
+    WAITLIST_REFERRALS: 'waitlist-referrals',
+    ADMIN_SCORING: 'admin-scoring',
+    DISCOVER_INVITE_CTA: 'discover-invite-cta',
+    ASYMMETRIC_INVITES: 'asymmetric-invites',
+    FOUNDING_CLOSE: 'founding-close',
 } as const;
 
 export type FeatureFlags = typeof FeatureFlags[keyof typeof FeatureFlags];

--- a/src/app/_lib/posthog.ts
+++ b/src/app/_lib/posthog.ts
@@ -13,15 +13,15 @@ export type FlagsMatcher = Record<string, undefined | {
 }>
 
 export const FeatureFlags = {
-    IS_APP_DISABLED: 'is_app_disabled',
-    INVITE_ONLY: 'invite-only',
-    FOUNDING_LANDING: 'founding-landing',
-    EMAIL_SEQUENCES: 'email-sequences',
-    WAITLIST_REFERRALS: 'waitlist-referrals',
     ADMIN_SCORING: 'admin-scoring',
-    DISCOVER_INVITE_CTA: 'discover-invite-cta',
     ASYMMETRIC_INVITES: 'asymmetric-invites',
+    DISCOVER_INVITE_CTA: 'discover-invite-cta',
+    EMAIL_SEQUENCES: 'email-sequences',
     FOUNDING_CLOSE: 'founding-close',
+    FOUNDING_LANDING: 'founding-landing',
+    INVITE_ONLY: 'invite-only',
+    IS_APP_DISABLED: 'is_app_disabled',
+    WAITLIST_REFERRALS: 'waitlist-referrals',
 } as const;
 
 export type FeatureFlags = typeof FeatureFlags[keyof typeof FeatureFlags];

--- a/src/app/app/settings/_components/BillingActions.tsx
+++ b/src/app/app/settings/_components/BillingActions.tsx
@@ -38,11 +38,9 @@ export default function BillingActions({ isProUser, pricing }: BillingActionsPro
     },
   });
 
-  const displayPrice = billingInterval === "monthly"
+  const monthlyEquivalent = billingInterval === "monthly"
     ? pricing.monthlyPrice
-    : pricing.annualPrice;
-
-  const intervalLabel = billingInterval === "monthly" ? "/mo" : "/yr";
+    : Math.round((pricing.annualPrice / 12) * 100) / 100;
 
   const annualSavings = pricing.monthlyPrice * 12 - pricing.annualPrice;
 
@@ -87,11 +85,11 @@ export default function BillingActions({ isProUser, pricing }: BillingActionsPro
         color="orange"
         size="md"
       >
-        Upgrade to Pro - ${displayPrice}{intervalLabel}
+        Upgrade to Pro - ${monthlyEquivalent}/mo
       </Button>
       {billingInterval === "annual" && annualSavings > 0 && (
         <Text size="xs" c="green">
-          Save ${annualSavings}/yr with annual billing
+          ${pricing.annualPrice}/yr — save ${annualSavings} vs monthly
         </Text>
       )}
       {error && (

--- a/src/app/app/settings/_components/BillingActions.tsx
+++ b/src/app/app/settings/_components/BillingActions.tsx
@@ -4,14 +4,8 @@ import { Button, SegmentedControl, Stack, Text } from "@mantine/core";
 import { IconCreditCard, IconExternalLink } from "@tabler/icons-react";
 import { useState } from "react";
 
+import type { PricingInfo } from "~/server/_utils/pricing";
 import { api } from "~/trpc/react";
-
-type PricingInfo = {
-  monthlyPrice: number;
-  annualPrice: number;
-  isFoundingPrice: boolean;
-  standardMonthlyPrice: number;
-};
 
 type BillingActionsProps = {
   isProUser: boolean;
@@ -23,24 +17,24 @@ export default function BillingActions({ isProUser, pricing }: BillingActionsPro
   const [billingInterval, setBillingInterval] = useState<"monthly" | "annual">("monthly");
 
   const createCheckout = api.subscription.createCheckoutSession.useMutation({
+    onError: (err) => {
+      setError(err.message ?? "Failed to create checkout session");
+    },
     onSuccess: (data) => {
       if (data.url) {
         window.location.href = data.url;
       }
-    },
-    onError: (err) => {
-      setError(err.message ?? "Failed to create checkout session");
     },
   });
 
   const createPortal = api.subscription.createPortalSession.useMutation({
+    onError: (err) => {
+      setError(err.message ?? "Failed to create portal session");
+    },
     onSuccess: (data) => {
       if (data.url) {
         window.location.href = data.url;
       }
-    },
-    onError: (err) => {
-      setError(err.message ?? "Failed to create portal session");
     },
   });
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,14 +3,14 @@ import type { NextAuthConfig } from "next-auth";
 import type { Adapter } from "next-auth/adapters";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 
+import { logger } from "~/_utils";
+import { FeatureFlags, getFeatureFlagVariant } from "~/app/_lib/posthog";
+import { providers, sessionConfig } from "~/auth.config";
 import { env } from "~/env";
 import { db } from "~/server/db";
 import { checkIfUserExists } from "~/server/_utils/auth/auth";
 import { generateUniqueInviteCode } from "~/server/_utils/invite";
 import { USER_ROLES, WAITLIST_APPROVED_CODE } from "~/server/_utils/roles";
-import { logger } from "~/_utils";
-import { FeatureFlags, getFeatureFlagVariant } from "~/app/_lib/posthog";
-import { providers, sessionConfig } from "~/auth.config";
 
 /**
  * Auth.js v5 configuration

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -9,6 +9,7 @@ import { checkIfUserExists } from "~/server/_utils/auth/auth";
 import { generateUniqueInviteCode } from "~/server/_utils/invite";
 import { USER_ROLES, WAITLIST_APPROVED_CODE } from "~/server/_utils/roles";
 import { logger } from "~/_utils";
+import { FeatureFlags, getFeatureFlagVariant } from "~/app/_lib/posthog";
 import { providers, sessionConfig } from "~/auth.config";
 
 /**
@@ -67,6 +68,23 @@ export const authConfig = {
       // Existing users always pass
       const existing = await db.user.findUnique({ where: { email: normalizedEmail } });
       if (existing) return true;
+
+      // Check if invite-only mode is disabled via PostHog feature flag
+      let inviteOnly: boolean | string | undefined;
+      try {
+        inviteOnly = await getFeatureFlagVariant(normalizedEmail, FeatureFlags.INVITE_ONLY);
+      } catch (error) {
+        // Fail-closed: if PostHog is unavailable, keep invite-only enforced
+        logger.warn("Failed to fetch invite-only feature flag, defaulting to invite-only", {
+          error: error instanceof Error ? error.message : "Unknown error",
+        });
+        inviteOnly = true;
+      }
+
+      // If invite-only is explicitly false, allow new users through (open registration)
+      if (inviteOnly === false) {
+        return true;
+      }
 
       // New users via Google OAuth: require PendingInviteValidation
       if (account?.provider === "google") {

--- a/src/env.js
+++ b/src/env.js
@@ -60,6 +60,10 @@ export const env = createEnv({
     RESEND_API_KEY: process.env.RESEND_API_KEY,
     STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
     STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET,
+    STRIPE_FOUNDING_MONTHLY_PRICE_ID: process.env.STRIPE_FOUNDING_MONTHLY_PRICE_ID,
+    STRIPE_FOUNDING_ANNUAL_PRICE_ID: process.env.STRIPE_FOUNDING_ANNUAL_PRICE_ID,
+    STRIPE_STANDARD_MONTHLY_PRICE_ID: process.env.STRIPE_STANDARD_MONTHLY_PRICE_ID,
+    STRIPE_STANDARD_ANNUAL_PRICE_ID: process.env.STRIPE_STANDARD_ANNUAL_PRICE_ID,
   },
 
 
@@ -108,6 +112,10 @@ export const env = createEnv({
     RESEND_API_KEY: z.string().optional(), // Make optional until API key is obtained
     STRIPE_SECRET_KEY: z.string(),
     STRIPE_WEBHOOK_SECRET: z.string(),
+    STRIPE_FOUNDING_MONTHLY_PRICE_ID: z.string().optional(),
+    STRIPE_FOUNDING_ANNUAL_PRICE_ID: z.string().optional(),
+    STRIPE_STANDARD_MONTHLY_PRICE_ID: z.string().optional(),
+    STRIPE_STANDARD_ANNUAL_PRICE_ID: z.string().optional(),
   },
 
   /**

--- a/src/env.js
+++ b/src/env.js
@@ -58,12 +58,12 @@ export const env = createEnv({
     NODE_ENV: process.env.NODE_ENV,
     ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
     RESEND_API_KEY: process.env.RESEND_API_KEY,
-    STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
-    STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET,
-    STRIPE_FOUNDING_MONTHLY_PRICE_ID: process.env.STRIPE_FOUNDING_MONTHLY_PRICE_ID,
     STRIPE_FOUNDING_ANNUAL_PRICE_ID: process.env.STRIPE_FOUNDING_ANNUAL_PRICE_ID,
-    STRIPE_STANDARD_MONTHLY_PRICE_ID: process.env.STRIPE_STANDARD_MONTHLY_PRICE_ID,
+    STRIPE_FOUNDING_MONTHLY_PRICE_ID: process.env.STRIPE_FOUNDING_MONTHLY_PRICE_ID,
+    STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
     STRIPE_STANDARD_ANNUAL_PRICE_ID: process.env.STRIPE_STANDARD_ANNUAL_PRICE_ID,
+    STRIPE_STANDARD_MONTHLY_PRICE_ID: process.env.STRIPE_STANDARD_MONTHLY_PRICE_ID,
+    STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET,
   },
 
 
@@ -110,12 +110,12 @@ export const env = createEnv({
       .default("development"),
     ANTHROPIC_API_KEY: z.string().optional(), // Optional — AI features degrade gracefully
     RESEND_API_KEY: z.string().optional(), // Make optional until API key is obtained
-    STRIPE_SECRET_KEY: z.string(),
-    STRIPE_WEBHOOK_SECRET: z.string(),
-    STRIPE_FOUNDING_MONTHLY_PRICE_ID: z.string().optional(),
     STRIPE_FOUNDING_ANNUAL_PRICE_ID: z.string().optional(),
-    STRIPE_STANDARD_MONTHLY_PRICE_ID: z.string().optional(),
+    STRIPE_FOUNDING_MONTHLY_PRICE_ID: z.string().optional(),
+    STRIPE_SECRET_KEY: z.string(),
     STRIPE_STANDARD_ANNUAL_PRICE_ID: z.string().optional(),
+    STRIPE_STANDARD_MONTHLY_PRICE_ID: z.string().optional(),
+    STRIPE_WEBHOOK_SECRET: z.string(),
   },
 
   /**

--- a/src/server/_utils/pricing.ts
+++ b/src/server/_utils/pricing.ts
@@ -1,0 +1,52 @@
+import { env } from "~/env";
+import { USER_ROLES, type UserRole } from "./roles";
+
+export type PricingInfo = {
+  monthlyPrice: number;
+  annualPrice: number;
+  isFoundingPrice: boolean;
+  standardMonthlyPrice: number;
+};
+
+const FOUNDING_ROLES: readonly UserRole[] = [
+  USER_ROLES.FOUNDING_MEMBER,
+  USER_ROLES.FOUNDER,
+  USER_ROLES.AMBASSADOR,
+];
+
+export function getPricingForRole(role: string): PricingInfo {
+  const isFounding = FOUNDING_ROLES.includes(role as UserRole);
+
+  if (isFounding) {
+    return {
+      monthlyPrice: 10,
+      annualPrice: 99,
+      isFoundingPrice: true,
+      standardMonthlyPrice: 19,
+    };
+  }
+
+  return {
+    monthlyPrice: 19,
+    annualPrice: 179,
+    isFoundingPrice: false,
+    standardMonthlyPrice: 19,
+  };
+}
+
+export function getPriceIdForCheckout(
+  role: string,
+  billingInterval: "monthly" | "annual",
+): string | null {
+  const isFounding = FOUNDING_ROLES.includes(role as UserRole);
+
+  if (isFounding) {
+    return billingInterval === "monthly"
+      ? (env.STRIPE_FOUNDING_MONTHLY_PRICE_ID ?? null)
+      : (env.STRIPE_FOUNDING_ANNUAL_PRICE_ID ?? null);
+  }
+
+  return billingInterval === "monthly"
+    ? (env.STRIPE_STANDARD_MONTHLY_PRICE_ID ?? null)
+    : (env.STRIPE_STANDARD_ANNUAL_PRICE_ID ?? null);
+}

--- a/src/server/_utils/pricing.ts
+++ b/src/server/_utils/pricing.ts
@@ -1,10 +1,11 @@
-import { env } from "~/env";
 import { USER_ROLES, type UserRole } from "./roles";
 
+import { env } from "~/env";
+
 export type PricingInfo = {
-  monthlyPrice: number;
   annualPrice: number;
   isFoundingPrice: boolean;
+  monthlyPrice: number;
   standardMonthlyPrice: number;
 };
 
@@ -19,17 +20,17 @@ export function getPricingForRole(role: string): PricingInfo {
 
   if (isFounding) {
     return {
-      monthlyPrice: 10,
       annualPrice: 99,
       isFoundingPrice: true,
+      monthlyPrice: 10,
       standardMonthlyPrice: 19,
     };
   }
 
   return {
-    monthlyPrice: 19,
     annualPrice: 179,
     isFoundingPrice: false,
+    monthlyPrice: 19,
     standardMonthlyPrice: 19,
   };
 }

--- a/src/server/api/routers/subscription.ts
+++ b/src/server/api/routers/subscription.ts
@@ -39,13 +39,13 @@ export const subscriptionRouter = createTRPCRouter({
   createCheckoutSession: protectedProcedure
     .input(
       z.object({
-        billingInterval: z.enum(["monthly", "annual"]).default("monthly"),
-      }).optional()
+        billingInterval: z.enum(["monthly", "annual"]),
+      })
     )
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
       const userEmail = ctx.session.user.email;
-      const billingInterval = input?.billingInterval ?? "monthly";
+      const billingInterval = input.billingInterval;
 
       if (!userEmail) {
         throw new Error("User email is required to create a checkout session");

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -23,6 +23,7 @@ export const userRouter = createTRPCRouter({
           city: true,
           state: true,
           country: true,
+          role: true,
         },
       });
     }),


### PR DESCRIPTION
## Summary
- Route founding members to locked $10/mo ($99/yr) prices, standard users to $19/mo ($179/yr) via role-based pricing utility
- Add monthly/annual billing toggle to settings page with founding badge + strikethrough display
- Extend FeatureFlags enum with 8 Phase B/C flags and wire `invite-only` flag into auth signIn callback (fail-closed)

## Details

### Stripe Founding Pricing
- **4 optional env vars** (`STRIPE_FOUNDING_MONTHLY_PRICE_ID`, etc.) — app works without them via inline `price_data` fallback
- **`src/server/_utils/pricing.ts`** — `getPricingForRole(role)` returns tier-specific prices; `getPriceIdForCheckout(role, interval)` returns Stripe Price ID or null
- **`createCheckoutSession`** now accepts `{ billingInterval: "monthly" | "annual" }` and looks up user role to determine pricing
- **Settings page** shows dynamic pricing: founding members see "$10" + "Founding Price" badge + "$19" strikethrough; standard users see "$19"
- **BillingActions** adds `SegmentedControl` toggle for monthly/annual with annual savings text

### PostHog Feature Flags
- 8 new flags added to `FeatureFlags` enum: `invite-only`, `founding-landing`, `email-sequences`, `waitlist-referrals`, `admin-scoring`, `discover-invite-cta`, `asymmetric-invites`, `founding-close`
- `invite-only` flag wired into `signIn` callback — when explicitly `false`, new users bypass invite requirement (open registration for Phase C)
- Fail-closed: PostHog unavailability or `undefined` keeps invite-only enforced

### No schema/webhook changes needed
Stripe Price objects permanently lock recurring charges. Webhooks sync status flags only.

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] App boots without `STRIPE_*_PRICE_ID` env vars
- [ ] Settings page: founding member sees $10/mo + "Founding Price" badge + $19 strikethrough
- [ ] Settings page: standard user sees $19/mo, no badge
- [ ] Monthly/annual toggle updates price display and checkout session
- [ ] `invite-only` flag true → new users without invite code blocked
- [ ] `invite-only` flag false → new users allowed through with role "standard"
- [ ] PostHog API failure → fail-closed (invite-only stays enforced)
- [ ] Create 8 feature flags in PostHog dashboard with correct defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Select monthly or annual billing with pricing that adjusts based on your user role.
  * Founding members receive special pricing with annual savings displayed.
  * Support for invite-only registration mode.
  * Infrastructure for upcoming features including email sequences and referral programs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->