### PR TITLE
feat: SEO quick wins — llms.txt, metadata, robots, sitemap

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,34 @@
+# ISO — The Photographer Network
+
+## What is ISO?
+ISO connects lead photographers with skilled second shooters for weddings, events, and sessions. It's a two-sided marketplace built by photographers, for photographers.
+
+## Who is it for?
+- Lead photographers who need a second shooter for an event
+- Second shooters looking for work opportunities
+- Wedding, event, and portrait photographers
+
+## Key Features
+- Create a professional photographer profile with portfolio
+- Search for second shooters by location, specialty, and availability
+- Discover photographers near you with swipe-based matching
+- Direct messaging to coordinate shoots
+- Booking management with application tracking
+- Reviews and ratings to build trust
+
+## Pricing
+- Basic (Free): Create profile, browse listings, direct messaging
+- Pro ($10-19/mo): Priority search, advanced booking, analytics
+
+## Markets
+Currently focused on Austin, TX and Denver, CO with plans to expand nationwide.
+
+## Founded by
+Penny Lamoreaux — wedding photographer with 12+ years of experience, featured in Wed Society Austin, Style Me Pretty, and The Knot.
+
+## Links
+- Website: https://myiso.app
+- Join: https://myiso.app/join
+- Waitlist: https://myiso.app/waitlist
+- About: https://myiso.app/about
+- Contact: https://myiso.app/contact

--- a/src/app/join/layout.tsx
+++ b/src/app/join/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Join ISO",
+  description:
+    "Join ISO — the invite-only photographer network. Connect with second shooters for weddings, events, and sessions in Austin, Denver, and beyond.",
+  openGraph: {
+    title: "Join ISO — The Photographer Network",
+    description:
+      "Join the invite-only network connecting lead photographers with skilled second shooters.",
+  },
+};
+
+export default function JoinLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,6 +29,9 @@ export const metadata = {
   description: "The Photographer Second Shooter Network",
   icons: [{ rel: "icon", url: "/favicon.ico" }],
   metadataBase: new URL("https://myiso.app"),
+  alternates: {
+    canonical: "/",
+  },
   openGraph: {
     type: "website",
     locale: "en_US",

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -2,11 +2,28 @@ import { type MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: {
-      userAgent: "*",
-      allow: "/",
-      disallow: ["/app/", "/api/"],
-    },
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/app/", "/api/"],
+      },
+      {
+        userAgent: "GPTBot",
+        allow: "/",
+        disallow: ["/app/", "/api/"],
+      },
+      {
+        userAgent: "ClaudeBot",
+        allow: "/",
+        disallow: ["/app/", "/api/"],
+      },
+      {
+        userAgent: "PerplexityBot",
+        allow: "/",
+        disallow: ["/app/", "/api/"],
+      },
+    ],
     sitemap: "https://myiso.app/sitemap.xml",
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -10,6 +10,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1,
     },
     {
+      url: `${baseUrl}/join`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/waitlist`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+    {
       url: `${baseUrl}/about`,
       lastModified: new Date(),
       changeFrequency: "monthly",

--- a/src/app/waitlist/layout.tsx
+++ b/src/app/waitlist/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Join the Waitlist",
+  description:
+    "Request an invite to ISO — the photographer second shooter network. Be first to connect with photographers in Austin, Denver, and more.",
+  openGraph: {
+    title: "Join the ISO Waitlist",
+    description:
+      "Request early access to the photographer network connecting leads with second shooters.",
+  },
+};
+
+export default function WaitlistLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}


### PR DESCRIPTION
## SEO Quick Wins (Day 1 items from SEO PRD)

Low-effort, high-impact changes for search and AI engine discoverability.

### Changes

**1. `llms.txt` (AEO)**
- New `public/llms.txt` describing ISO for AI crawlers (ChatGPT, Perplexity, etc.)
- Follows the [llmstxt.org](https://llmstxt.org) emerging standard

**2. Page Metadata**
- `/join` — layout.tsx with title, description, OG tags
- `/waitlist` — layout.tsx with title, description, OG tags
- Both were `"use client"` pages with no metadata; layouts provide it without refactoring

**3. Canonical URLs**
- Added `alternates.canonical` to root layout metadata
- Prevents duplicate content from trailing slashes, www vs non-www, etc.

**4. robots.txt**
- Explicit allow rules for AI crawlers: GPTBot, ClaudeBot, PerplexityBot
- Ensures AI search engines can index public content

**5. Sitemap**
- Added `/join` (priority 0.9) and `/waitlist` (priority 0.9) — high-traffic entry points from marketing

### No Breaking Changes
All additive — new files and metadata only.