### PR TITLE
fix: wire PortfolioUpload into profile page

### DIFF
--- a/src/app/_components/profiles/ProfilePage.tsx
+++ b/src/app/_components/profiles/ProfilePage.tsx
@@ -31,6 +31,7 @@ import { FavoriteButton } from "./FavoriteButton";
 import EditProfile from "./EditProfile";
 import EmptyState from "../EmptyState";
 import { Notification } from "../Notification";
+import { PortfolioUpload } from "../portfolio";
 import ProfileAvatar from "./ProfileAvatar";
 
 import { getPortfolioImages } from "~/app/_server_utils/";
@@ -301,16 +302,18 @@ export const ProfilePage = async ({
         <Box style={{ gridColumn: resources.length > 0 ? "span 2" : "span 1" }}>
           {resources.length > 0 ? (
             <Paper p="lg" radius="md" withBorder>
-              <Text
-                size="xs"
-                fw={700}
-                c="dimmed"
-                tt="uppercase"
-                mb="md"
-                style={{ letterSpacing: 1 }}
-              >
-                Portfolio
-              </Text>
+              <Group justify="space-between" mb="md">
+                <Text
+                  size="xs"
+                  fw={700}
+                  c="dimmed"
+                  tt="uppercase"
+                  style={{ letterSpacing: 1 }}
+                >
+                  Portfolio
+                </Text>
+                {isSelf && <PortfolioUpload />}
+              </Group>
               <SimpleGrid
                 cols={{ base: 2, sm: 3 }}
                 spacing="sm"
@@ -356,6 +359,7 @@ export const ProfilePage = async ({
                     Upload photos to showcase your work and attract more clients.
                   </Text>
                 </Stack>
+                <PortfolioUpload />
               </Stack>
             </Paper>
           ) : null}


### PR DESCRIPTION
## Problem

The `PortfolioUpload` component existed in `src/app/_components/portfolio/PortfolioUpload.tsx` but was never imported or rendered anywhere. Users had no way to upload portfolio images.

Profile avatar upload works (hover on avatar → modal), but portfolio was a dead end.

## Fix

Wire `PortfolioUpload` into `ProfilePage.tsx` in two places:

1. **Portfolio section header** — "Upload Image" button appears next to the "Portfolio" label when viewing your own profile (alongside existing images)
2. **Empty state** — Upload button below the "No portfolio images yet" message

Both only render for `isSelf` (own profile). Other users see the portfolio or nothing.

## No other changes
- PortfolioUpload component unchanged
- Cloudinary integration already working
- Upload flow: dropzone → base64 → Cloudinary REST API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portfolio upload is now accessible directly from your Profile page when viewing your own profile.
  * An upload action appears beside the Portfolio section title and within the empty-state card if no items exist.
  * Layout updates align the upload action to the right for clear visibility across both populated and empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->