### PR TITLE
fix: staging deployment — WASM patch, NODE_ENV, and auth config

### DIFF
--- a/scripts/patch-prisma-wasm.sh
+++ b/scripts/patch-prisma-wasm.sh
@@ -46,7 +46,11 @@ if wasm_import in content:
 elif old_fast_import in content:
     content = content.replace(old_fast_import, wasm_import)
     print("Replaced fast WASM import with bg WASM import.")
-elif "__prismaQueryWasm" in content:
+elif re.search(
+    r'^\s*import\s+__prismaQueryWasm\s+from\s+"\.\/query_compiler(?:_fast)?_bg\.wasm";\s*$',
+    content,
+    re.MULTILINE,
+):
     print("Already patched, skipping import insertion.")
 else:
     content = content[:first_import_end] + wasm_import + content[first_import_end:]

--- a/scripts/patch-prisma-wasm.sh
+++ b/scripts/patch-prisma-wasm.sh
@@ -47,11 +47,17 @@ elif old_fast_import in content:
     content = content.replace(old_fast_import, wasm_import)
     print("Replaced fast WASM import with bg WASM import.")
 elif re.search(
-    r'^\s*import\s+__prismaQueryWasm\s+from\s+"\.\/query_compiler(?:_fast)?_bg\.wasm";\s*$',
+    r'^\s*import\s+__prismaQueryWasm\s+from\s+["\']\.\/query_compiler(?:_fast)?_bg\.wasm["\'];\s*$',
     content,
     re.MULTILINE,
 ):
-    print("Already patched, skipping import insertion.")
+    content = re.sub(
+        r'^\s*import\s+__prismaQueryWasm\s+from\s+["\']\.\/query_compiler(?:_fast)?_bg\.wasm["\'];\s*$',
+        wasm_import.strip(),
+        content,
+        flags=re.MULTILINE,
+    ) + ("\n" if not content.endswith("\n") else "")
+    print("Normalized existing __prismaQueryWasm import to bg WASM import.")
 else:
     content = content[:first_import_end] + wasm_import + content[first_import_end:]
     print(f"Added WASM import at line 2")

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,6 +1,5 @@
 import type { NextAuthConfig } from "next-auth";
 import GoogleProvider, { type GoogleProfile } from "next-auth/providers/google";
-import ResendProvider from "next-auth/providers/resend";
 import { env } from "~/env";
 
 /**
@@ -13,8 +12,9 @@ export const sessionConfig = {
 };
 
 /**
- * Shared provider configuration
- * Used by both main auth and edge middleware configs
+ * Edge-compatible providers (no adapter required).
+ * Resend/email provider is excluded here — it needs a DB adapter
+ * and is added only in auth.ts where PrismaAdapter is configured.
  */
 export const providers = [
   GoogleProvider({
@@ -28,14 +28,6 @@ export const providers = [
       emailVerified: profile.email_verified ? new Date() : null,
     }),
   }),
-  ...(env.RESEND_API_KEY
-    ? [
-        ResendProvider({
-          from: env.EMAIL_FROM,
-          apiKey: env.RESEND_API_KEY,
-        }),
-      ]
-    : []),
 ];
 
 /**

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -26,7 +26,7 @@ export const authConfig = {
   providers: [
     ...providers,
     ...(env.RESEND_API_KEY
-      ? [ResendProvider({ from: env.EMAIL_FROM, apiKey: env.RESEND_API_KEY })]
+      ? [ResendProvider({ apiKey: env.RESEND_API_KEY, from: env.EMAIL_FROM })]
       : []),
   ],
   callbacks: {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,6 +2,7 @@ import NextAuth from "next-auth";
 import type { NextAuthConfig } from "next-auth";
 import type { Adapter } from "next-auth/adapters";
 import { PrismaAdapter } from "@auth/prisma-adapter";
+import ResendProvider from "next-auth/providers/resend";
 
 import { logger } from "~/_utils";
 import { FeatureFlags, getFeatureFlagVariant } from "~/app/_lib/posthog";
@@ -22,7 +23,12 @@ import { USER_ROLES, WAITLIST_APPROVED_CODE } from "~/server/_utils/roles";
  */
 export const authConfig = {
   adapter: PrismaAdapter(db) as Adapter,
-  providers,
+  providers: [
+    ...providers,
+    ...(env.RESEND_API_KEY
+      ? [ResendProvider({ from: env.EMAIL_FROM, apiKey: env.RESEND_API_KEY })]
+      : []),
+  ],
   callbacks: {
     jwt: async ({ account, user, token }) => {
       if (account) {

--- a/src/server/api/routers/auth.ts
+++ b/src/server/api/routers/auth.ts
@@ -224,6 +224,7 @@ export const authRouter = createTRPCRouter({
       });
 
       const isDev = env.NODE_ENV === 'development';
+      logger.info("requestMobileOtp", { isDev, NODE_ENV: env.NODE_ENV, email: normalizedEmail });
       const code = isDev ? '000000' : generateVerificationCode();
       const expires = new Date(Date.now() + 1000 * 60 * 10); // 10 minutes
 
@@ -234,6 +235,7 @@ export const authRouter = createTRPCRouter({
       if (!isDev) {
         const { sendEmail } = await import("../../_lib/email");
         const { renderMobileOtpEmail } = await import("../../_lib/emails");
+        logger.info("Sending OTP email", { email: normalizedEmail });
         const html = await renderMobileOtpEmail({ code });
         const emailResult = await sendEmail({ email: normalizedEmail, subject: `${code} is your ISO sign-in code`, html });
 
@@ -241,6 +243,7 @@ export const authRouter = createTRPCRouter({
           logger.error("Error sending OTP email", { error: emailResult.error });
           throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to send code. Please try again.' });
         }
+        logger.info("OTP email sent successfully", { email: normalizedEmail });
       }
 
       return { sent: true, devCode: isDev ? code : undefined };

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,12 +12,18 @@ binding = "DB"
 database_name = "my-iso-db"
 database_id = "aad00920-a190-4144-b414-c17ff5388755"
 
+[vars]
+NODE_ENV = "production"
+
 [observability.logs]
 enabled = true
 invocation_logs = true
 
 [env.staging]
 name = "my-iso-staging"
+
+[env.staging.vars]
+NODE_ENV = "production"
 
 [[env.staging.d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## Summary
- Fix Prisma WASM patch script to use `query_compiler_bg.wasm` instead of the fast variant — Prisma's instantiation code provides `./query_compiler_bg.js` as the import key, so the WASM module must match
- Handle already-patched handler without erroring out (was causing `wrangler deploy` to be skipped)
- Set `NODE_ENV=production` in `wrangler.toml` for both staging and prod — CF Workers defaults to `"development"` otherwise, causing OTP to use `000000` instead of sending real emails
- Move Resend provider from shared edge middleware config to `auth.ts` only — email providers require a DB adapter which isn't available in the edge runtime
- Add structured logging around OTP email send for observability

## Test plan
- [ ] Login OTP sends real email on staging
- [ ] `./scripts/patch-prisma-wasm.sh` succeeds on already-patched handler
- [ ] Google OAuth still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added staging environment config with a dedicated database and enhanced observability.

* **Bug Fixes**
  * Improved Prisma WASM patching with safer detection, normalization, and clearer patching messages.

* **Chores**
  * Resend email provider reworked: removed from edge-compatible list and now included conditionally as an optional provider.
  * Added diagnostic logging around email/OTP request flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->