### PR TITLE
fix: standardize date formatting with UTC→local timezone conversion

### DIFF
--- a/src/_lib/dayjs.ts
+++ b/src/_lib/dayjs.ts
@@ -9,13 +9,17 @@ export default dayjs;
 
 /** Convert a UTC date to the user's local timezone and format it. */
 export function formatLocalDate(
-  date: Date | string,
+  date: Date | string | null | undefined,
   format = "MMM D, YYYY",
 ): string {
+  if (!date) return "";
   return dayjs(date).utc().local().format(format);
 }
 
 /** Convert a UTC date to local timezone with time included. */
-export function formatLocalDateTime(date: Date | string): string {
+export function formatLocalDateTime(
+  date: Date | string | null | undefined,
+): string {
+  if (!date) return "";
   return dayjs(date).utc().local().format("MMM D, YYYY h:mm A");
 }

--- a/src/_lib/dayjs.ts
+++ b/src/_lib/dayjs.ts
@@ -6,3 +6,16 @@ dayjs.extend(relativeTime);
 dayjs.extend(utc);
 
 export default dayjs;
+
+/** Convert a UTC date to the user's local timezone and format it. */
+export function formatLocalDate(
+  date: Date | string,
+  format = "MMM D, YYYY",
+): string {
+  return dayjs(date).utc().local().format(format);
+}
+
+/** Convert a UTC date to local timezone with time included. */
+export function formatLocalDateTime(date: Date | string): string {
+  return dayjs(date).utc().local().format("MMM D, YYYY h:mm A");
+}

--- a/src/app/_components/LocalDate.tsx
+++ b/src/app/_components/LocalDate.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { formatLocalDate } from "~/_lib/dayjs";
+
+type LocalDateProps = {
+  date: Date | string;
+  format?: string;
+};
+
+/** Client component that formats a UTC date in the user's local timezone. Use this in server components. */
+export default function LocalDate({ date, format }: LocalDateProps) {
+  return <>{formatLocalDate(date, format)}</>;
+}

--- a/src/app/_components/LocalDate.tsx
+++ b/src/app/_components/LocalDate.tsx
@@ -1,13 +1,22 @@
 "use client";
 
+import { useEffect, useState } from "react";
+
 import { formatLocalDate } from "~/_lib/dayjs";
 
 type LocalDateProps = {
-  date: Date | string;
+  date: string;
   format?: string;
 };
 
 /** Client component that formats a UTC date in the user's local timezone. Use this in server components. */
 export default function LocalDate({ date, format }: LocalDateProps) {
-  return <>{formatLocalDate(date, format)}</>;
+  const [formatted, setFormatted] = useState<string | null>(null);
+
+  useEffect(() => {
+    setFormatted(formatLocalDate(date, format));
+  }, [date, format]);
+
+  if (!formatted) return null;
+  return <>{formatted}</>;
 }

--- a/src/app/_components/bookings/BookingCard.tsx
+++ b/src/app/_components/bookings/BookingCard.tsx
@@ -18,6 +18,7 @@ import {
 } from "@tabler/icons-react";
 import Link from "next/link";
 
+import { formatLocalDate } from "~/_lib/dayjs";
 import { logger } from "~/_utils";
 import { api } from "~/trpc/react";
 
@@ -129,7 +130,7 @@ export default function BookingCard({
               <Group gap={4}>
                 <IconCalendar size={14} color="var(--mantine-color-dimmed)" />
                 <Text size="xs" c="dimmed">
-                  {new Date(event.date).toLocaleDateString()}
+                  {formatLocalDate(event.date)}
                 </Text>
               </Group>
             </Group>
@@ -252,7 +253,7 @@ export default function BookingCard({
 
         {/* Timestamp */}
         <Text size="xs" c="dimmed">
-          Applied {new Date(booking.createdAt).toLocaleDateString()}
+          Applied {formatLocalDate(booking.createdAt)}
         </Text>
       </Stack>
     </Paper>

--- a/src/app/_components/events/EventCard.tsx
+++ b/src/app/_components/events/EventCard.tsx
@@ -13,6 +13,7 @@ import EventCardSkeleton from "./EventCardSkeleton";
 import AddCommentForm from "../AddCommentForm";
 import Timemarker from "../Timemarker";
 
+import { formatLocalDate } from "~/_lib/dayjs";
 import { api } from "~/trpc/react";
 
 type EventCardProps = {
@@ -88,7 +89,7 @@ export default function EventCard({ eventId, initialCommentCount = 0, isEventPag
                                 </Badge>
                             )}
                             <Badge variant="light" size="sm">
-                                {data.date.toLocaleDateString()}
+                                {formatLocalDate(data.date)}
                             </Badge>
                             <Badge variant="outline" size="sm">
                                 {data.duration} hour{data.duration > 1 ? "s" : ""}

--- a/src/app/_components/profiles/ReviewsList.tsx
+++ b/src/app/_components/profiles/ReviewsList.tsx
@@ -9,6 +9,7 @@ import {
 } from "@mantine/core";
 import { IconMessageCircle } from "@tabler/icons-react";
 
+import { formatLocalDate } from "~/_lib/dayjs";
 import EmptyState from "../EmptyState";
 import { StarRating } from "./PublicProfileHero";
 
@@ -32,11 +33,7 @@ type ReviewsListProps = {
 };
 
 function formatDate(date: Date): string {
-  return new Date(date).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
+  return formatLocalDate(date, "MMMM D, YYYY");
 }
 
 export default function ReviewsList({

--- a/src/app/_components/profiles/ReviewsList.tsx
+++ b/src/app/_components/profiles/ReviewsList.tsx
@@ -9,9 +9,10 @@ import {
 } from "@mantine/core";
 import { IconMessageCircle } from "@tabler/icons-react";
 
-import { formatLocalDate } from "~/_lib/dayjs";
 import EmptyState from "../EmptyState";
 import { StarRating } from "./PublicProfileHero";
+
+import { formatLocalDate } from "~/_lib/dayjs";
 
 type Review = {
   id: string;

--- a/src/app/app/admin/waitlist/page.tsx
+++ b/src/app/app/admin/waitlist/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "@tabler/icons-react";
 import { useState } from "react";
 
+import { formatLocalDate } from "~/_lib/dayjs";
 import PageHeader from "~/app/_components/PageHeader";
 import { api } from "~/trpc/react";
 
@@ -145,7 +146,7 @@ export default function Page() {
                   )}
                 </Group>
                 <Text size="xs" c="dimmed">
-                  Applied {new Date(entry.createdAt).toLocaleDateString()}
+                  Applied {formatLocalDate(entry.createdAt)}
                 </Text>
               </Stack>
 

--- a/src/app/app/invites/page.tsx
+++ b/src/app/app/invites/page.tsx
@@ -21,6 +21,7 @@ import {
   IconRefresh,
 } from "@tabler/icons-react";
 
+import { formatLocalDate } from "~/_lib/dayjs";
 import { Avatar } from "~/app/_components/Avatar";
 import PageHeader from "~/app/_components/PageHeader";
 import { api } from "~/trpc/react";
@@ -157,7 +158,7 @@ export default function Page() {
                   </Text>
                 </Box>
                 <Text size="xs" c="dimmed">
-                  {new Date(r.redeemedAt).toLocaleDateString()}
+                  {formatLocalDate(r.redeemedAt)}
                 </Text>
               </Group>
             ))}

--- a/src/app/app/search/_components/EventSearchCard.tsx
+++ b/src/app/app/search/_components/EventSearchCard.tsx
@@ -3,6 +3,7 @@
 import { Card, Group, Text, Title, Badge, Image } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import Link from 'next/link';
+import { formatLocalDate } from '~/_lib/dayjs';
 import type { RouterOutputs } from '~/trpc/react';
 
 type EventSearchCardProps = {
@@ -21,7 +22,7 @@ export default function EventSearchCard({ event }: EventSearchCardProps) {
           <Group justify="space-between" mb="md" wrap="wrap">
             <Text size="sm" fs="italic" c="dimmed">{event.location}</Text>
             <Group gap="xs">
-              <Badge size="lg" variant="transparent">{event.date.toLocaleDateString()}</Badge>
+              <Badge size="lg" variant="transparent">{formatLocalDate(event.date)}</Badge>
               <Badge size="sm" variant="outline">
                 {event.duration} Hour{event.duration > 1 && "s"}
               </Badge>

--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -112,7 +112,7 @@ export default async function SettingsPage() {
                 <Text size="sm" c="orange">
                   Your subscription is canceled but remains active until{" "}
                   {subscription.expiresAt
-                    ? <LocalDate date={subscription.expiresAt} />
+                    ? <LocalDate date={new Date(subscription.expiresAt).toISOString()} />
                     : "the end of your billing period"}
                   .
                 </Text>

--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -21,6 +21,7 @@ import {
 } from "@tabler/icons-react";
 
 import BillingActions from "./_components/BillingActions";
+import LocalDate from "~/app/_components/LocalDate";
 import PageHeader from "~/app/_components/PageHeader";
 import { auth } from "~/auth";
 import { getPricingForRole } from "~/server/_utils/pricing";
@@ -111,7 +112,7 @@ export default async function SettingsPage() {
                 <Text size="sm" c="orange">
                   Your subscription is canceled but remains active until{" "}
                   {subscription.expiresAt
-                    ? new Date(subscription.expiresAt).toLocaleDateString()
+                    ? <LocalDate date={subscription.expiresAt} />
                     : "the end of your billing period"}
                   .
                 </Text>


### PR DESCRIPTION
## Summary
- Replaced all `.toLocaleDateString()` calls with explicit `dayjs(date).utc().local()` conversion to match the existing `Timemarker` pattern
- Added `formatLocalDate` and `formatLocalDateTime` utilities to `src/_lib/dayjs.ts`
- Created `LocalDate` client component for rendering dates in server components (SettingsPage) — ensures dates display in the user's timezone, not the server's (UTC on Cloudflare Workers)

**Files fixed:** EventCard, EventSearchCard, BookingCard, ReviewsList, InvitesPage, WaitlistPage, SettingsPage

## Test plan
- [ ] Verify event dates display correctly in user's local timezone on EventCard and EventSearchCard
- [ ] Verify booking dates and application dates display correctly on BookingCard
- [ ] Verify review dates display correctly on profile pages
- [ ] Verify subscription expiry date on Settings page renders in local timezone (server component edge case)
- [ ] Verify invite redemption dates and waitlist application dates display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized date and datetime formatting utilities to consistently convert UTC timestamps to the user’s local timezone.
  * Introduced a LocalDate component for standardized client-side date rendering.

* **Refactor**
  * Replaced inline locale date formatting across bookings, events, reviews, admin, invites, search, and settings with the unified formatter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->